### PR TITLE
Fix 404 error on about page

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -8,7 +8,7 @@ import { defineCollection, reference, z } from "astro:content";
  */
 const pages = defineCollection({
   loader: glob({
-    pattern: "**/*.md",
+    pattern: "**/*.{md,mdx}",
     base: "./src/content/pages",
   }),
   schema: ({ image }) =>


### PR DESCRIPTION
Update the file pattern to include `.mdx` files, resolving issues with 404 errors when accessing certain pages.