### PR TITLE
Remove react-compiler-runtime dependency

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -35,7 +35,6 @@
     "npm:astro@^5.1.1": "5.1.1_@types+node@22.5.4_vite@6.0.5__@types+node@22.5.4_zod@3.24.1",
     "npm:exiftool-vendored@*": "29.0.0",
     "npm:globals@^15.13.0": "15.14.0",
-    "npm:react-compiler-runtime@^19.0.0-beta-201e55d-20241215": "19.0.0-beta-201e55d-20241215_react@19.0.0",
     "npm:react-dom@19": "19.0.0_react@19.0.0",
     "npm:react@19": "19.0.0",
     "npm:rehype-external-links@3": "3.0.0",
@@ -3981,12 +3980,6 @@
     "radix3@1.1.2": {
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="
     },
-    "react-compiler-runtime@19.0.0-beta-201e55d-20241215_react@19.0.0": {
-      "integrity": "sha512-jBEo/UqVgiz6veJjhQMoNaGQLKUQwzMQpiYrA4XsGVOC2sElDF0oMjic5107LitP988yHrqDDZwZirS4OAEqyA==",
-      "dependencies": [
-        "react"
-      ]
-    },
     "react-dom@19.0.0_react@19.0.0": {
       "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "dependencies": [
@@ -5137,7 +5130,6 @@
         "npm:astro-seo@~0.8.4",
         "npm:astro@^5.1.1",
         "npm:globals@^15.13.0",
-        "npm:react-compiler-runtime@^19.0.0-beta-201e55d-20241215",
         "npm:react-dom@19",
         "npm:react@19",
         "npm:rehype-external-links@3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "astro-robots-txt": "^1.0.0",
     "astro-seo": "^0.8.4",
     "globals": "^15.13.0",
-    "react-compiler-runtime": "^19.0.0-beta-201e55d-20241215",
     "react-dom": "^19.0.0",
     "react": "^19.0.0",
     "rehype-external-links": "^3.0.0",


### PR DESCRIPTION
Eliminate the react-compiler-runtime as it was only necessary for the Deno Vite plugin.