### PR TITLE
Rename deploy project and fix workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Deploy
         uses: denoland/deployctl@v1
         with:
-          project: "tugrul"
+          project: "trl"
           entrypoint: "server/entry.mjs"
           root: "dist"
 


### PR DESCRIPTION
Update the project name in the deployment configuration from "tugrul" to "trl."