### PR TITLE
Don't use deno canary on vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "astro",
-  "installCommand": "npm install -g deno && deno upgrade canary && deno install",
+  "installCommand": "npm install -g deno && deno install",
   "buildCommand": "deno task build",
   "cleanUrls": true,
   "headers": [


### PR DESCRIPTION
Since 2.5.1 is now released